### PR TITLE
docs: remove refs to btcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,18 @@ In the following, we go through important parameters of the `stakerd.conf` file.
    in [Create a Babylon keyring with funds](#create-a-babylon-keyring-with-funds)
 2. Ensure that the `KeyringDirectory` is set to the location where the keyring is
    stored.
-3. Make sure to use the  `test` keyring backend.
-4. To change the babylon RPC/GRPC address, you can set
+3. Ensure to use the `test` keyring backend
+4. Ensure you use the correct `ChainID` for the network you're connecting to. For
+   example, for Babylon [devnet](https://rpc.devnet.babylonchain.io/status), the
+   chain ID is `bbn-dev-5`.
+5. To change the Babylon RPC/GRPC address, update the following:
 
-   ```bash
-   RPCAddr = https://rpc.devnet.babylonchain.io:443
-   GRPCAddr = https://grpc.devnet.babylonchain.io:443
-   ```
-5. If you encounter any gas-related errors while performing staking operations,
+    ```bash
+    RPCAddr = https://rpc.devnet.babylonchain.io:443
+    GRPCAddr = https://grpc.devnet.babylonchain.io:443
+    ```
+   The above addresses are for Babylon devnet.
+6. If you encounter any gas-related errors while performing staking operations,
    consider adjusting the `GasAdjustment` and `GasPrices` parameters. For example,
    you can set:
 

--- a/README.md
+++ b/README.md
@@ -96,24 +96,18 @@ to create a keyring and request funds.
 #### 2. Start Bitcoin node with wallet
 
 The `stakerd` daemon requires a running Bitcoin node and a wallet loaded with signet
-Bitcoins. You can configure the daemon to connect to either `bitcoind`
-or `btcd` node types.
+Bitcoins.
 
-Follow the official guides to install and run the Bitcoin node:
+Choose between two popular Bitcoin node implementations: `bitcoind` (Bitcoin Core)
+or `btcd`. While both are compatible, we recommend using `bitcoind`. Currently,
+stakerd supports Bitcoin Core version 24.1.
 
-- ##### Bitcoin Core (bitcoind)
-    - Official Bitcoin Core
-      website: [Bitcoin core](https://bitcoin.org/en/bitcoin-core/)
+You can download Bitcoin Core version 24.1 from the official
+release [page](https://bitcoincore.org/en/releases/24.1/).
 
-    - For information on Signet, you can
-      check [this](https://en.bitcoin.it/wiki/Signet) wiki page.
-
-    - Currently we only support Bitcoin Core
-      version [24.1](https://bitcoincore.org/en/releases/24.1/)
-
-- ##### btcd
-
-  GitHub repository for btcd: [btcd](https://github.com/btcsuite/btcd)
+For more information on Signet, you can
+check [this](https://en.bitcoin.it/wiki/Signet)
+wiki page.
 
 **Notes**:
 
@@ -262,26 +256,8 @@ DisableTls = true
 
 #### BTC Node type specific configuration
 
-If you selected `btcd` as the node type, then you can configure the btcd node using
-the following parameters.
-
-```bash
-[btcd]
-# The daemon's rpc listening address. 
-# note: P2P port for signet is 38332
-# for other networks, check the ref below'
-# https://github.com/btcsuite/btcd/blob/17fdc5219b363c98df12e3ed7849a14f4820d93f/params.go#L23
-RPCHost = 127.0.0.1:38332
-
-# Username for RPC connections
-RPCUser = user
-
-# Password for RPC connections
-RPCPass = pass
-```
-
-If you selected `bitcoind` as the node type, then you can configure it using the
-following parameters.
+Make sure to update the following important parameters related to your `bitcoind`
+config.
 
 ```bash
 [bitcoind]
@@ -299,10 +275,10 @@ RPCUser = user
 # Password for RPC connections
 RPCPass = pass
 
-; The address listening for ZMQ connections to deliver raw block notifications
+# The address listening for ZMQ connections to deliver raw block notifications
 ZMQPubRawBlock = tcp://127.0.0.1:29001
 
-; The address listening for ZMQ connections to deliver raw transaction notifications
+# The address listening for ZMQ connections to deliver raw transaction notifications
 ZMQPubRawTx = tcp://127.0.0.1:29002
 ```
 
@@ -324,7 +300,6 @@ the `--rpclisten` flag.
 stakerd --rpclisten 'localhost:15812'
 
 time="2023-12-08T11:48:04+05:30" level=info msg="Starting StakerApp"
-time="2023-12-08T11:48:04+05:30" level=info msg="Connecting to node backend: btcd"
 ```
 
 All the available CLI options can be viewed using the `--help` flag. These options

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ In the following, we go through important parameters of the `stakerd.conf` file.
 5. To change the Babylon RPC/GRPC address, update the following:
 
     ```bash
-    RPCAddr = https://rpc.devnet.babylonchain.io:443
-    GRPCAddr = https://grpc.devnet.babylonchain.io:443
+    RPCAddr = https://rpc.devnet.babylonchain.io:443 # rpc node address
+    GRPCAddr = https://grpc.devnet.babylonchain.io:443 # grpc node address
     ```
    The above addresses are for Babylon devnet.
 6. If you encounter any gas-related errors while performing staking operations,

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ In the following, we go through important parameters of the `stakerd.conf` file.
 2. Ensure that the `KeyringDirectory` is set to the location where the keyring is
    stored.
 3. Make sure to use the  `test` keyring backend.
+4. To change the babylon RPC/GRPC address, you can set
+
+   ```bash
+   RPCAddr = https://rpc.devnet.babylonchain.io:443
+   GRPCAddr = https://grpc.devnet.babylonchain.io:443
+   ```
+5. If you encounter any gas-related errors while performing staking operations, consider
+   adjusting the `GasAdjustment` and `GasPrices` parameters. For example, you can set:
+
+   ```bash
+   GasAdjustment = 1.5
+   GasPrices = 0.002ubbn
+   ```
 
 ```bash
 [babylon]
@@ -182,24 +195,6 @@ GasPrices = 0.01ubbn
 KeyDirectory = /Users/<user>/Library/Application Support/Stakerd
 ```
 
-**Additional Notes:**
-
-1. To change the babylon rpc/grpc address, you can set
-
-   ```bash
-   RPCAddr = https://rpc.devnet.babylonchain.io:443
-   GRPCAddr = https://grpc.devnet.babylonchain.io:443
-   ```
-
-2. If you encounter any gas-related errors while performing staking operations,
-   consider adjusting the `GasAdjustment` and `GasPrices` parameters. For example,
-   you can set:
-
-   ```bash
-   GasAdjustment = 1.5
-   GasPrices = 0.002ubbn
-   ```
-
 #### BTC Node configuration
 
 **Notes:**
@@ -226,7 +221,7 @@ FeeMode = static
 
 #### BTC Wallet configuration
 
-**Notes:**
+**Note:**
 Make sure you create a BTC wallet, name it appropriately, and load it with enough
 signet BTC.
 

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ DisableTls = true
 
 #### BTC Node type specific configuration
 
-Make sure to update the following important parameters related to your `bitcoind`
-config.
+Make sure to replace the following important parameters related to `bitcoind` as per
+your setup.
 
 ```bash
 [bitcoind]

--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ In the following, we go through important parameters of the `stakerd.conf` file.
    stored.
 3. Ensure to use the `test` keyring backend
 4. Ensure you use the correct `ChainID` for the network you're connecting to. For
-   example, for Babylon [devnet](https://rpc.devnet.babylonchain.io/status), the
-   chain ID is `bbn-dev-5`.
+   example, for Babylon devnet, the chain ID is `bbn-dev-5`.
 5. To change the Babylon RPC/GRPC address, update the following:
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ stakerd supports Bitcoin Core version 24.1.
 You can download Bitcoin Core version 24.1 from the official
 release [page](https://bitcoincore.org/en/releases/24.1/).
 
-For more information on Signet, you can
-check [this](https://en.bitcoin.it/wiki/Signet)
-wiki page.
+For more information on Signet, you can check the
+Bitcoin [wiki](https://en.bitcoin.it/wiki/Signet)
+page.
 
 **Notes**:
 
@@ -160,8 +160,9 @@ In the following, we go through important parameters of the `stakerd.conf` file.
    RPCAddr = https://rpc.devnet.babylonchain.io:443
    GRPCAddr = https://grpc.devnet.babylonchain.io:443
    ```
-5. If you encounter any gas-related errors while performing staking operations, consider
-   adjusting the `GasAdjustment` and `GasPrices` parameters. For example, you can set:
+5. If you encounter any gas-related errors while performing staking operations,
+   consider adjusting the `GasAdjustment` and `GasPrices` parameters. For example,
+   you can set:
 
    ```bash
    GasAdjustment = 1.5


### PR DESCRIPTION
Remove references and mention about btcd, we want to encourage operators to use bitcoind instead. 

I'll further enhance bitcoin related instructions in future pr to make it more clear on how to setup a signet node.