### PR TITLE
Add possiblity to send concurrent transactions

### DIFF
--- a/babylonclient/msgsender.go
+++ b/babylonclient/msgsender.go
@@ -71,7 +71,7 @@ type BabylonMsgSender struct {
 func NewBabylonMsgSender(
 	cl BabylonClient,
 	logger *logrus.Logger,
-	maxConcurrentTransactions uint64,
+	maxConcurrentTransactions uint32,
 ) *BabylonMsgSender {
 	s := semaphore.NewWeighted(int64(maxConcurrentTransactions))
 	return &BabylonMsgSender{

--- a/babylonclient/msgsender.go
+++ b/babylonclient/msgsender.go
@@ -124,7 +124,9 @@ func (b *BabylonMsgSender) isBabylonBtcLcReady(
 }
 
 func (m *BabylonMsgSender) sendDelegationAsync(stakingTxHash *chainhash.Hash, req *sendDelegationRequest) {
-	m.s.Acquire(context.Background(), 1)
+	// do not check the error, as only way for it to return err is if provided context would be cancelled
+	// which can't happen here
+	_ = m.s.Acquire(context.Background(), 1)
 	m.wg.Add(1)
 	go func() {
 		defer m.s.Release(1)
@@ -154,7 +156,9 @@ func (m *BabylonMsgSender) sendDelegationAsync(stakingTxHash *chainhash.Hash, re
 }
 
 func (m *BabylonMsgSender) sendUndelegationAsync(stakingTxHash *chainhash.Hash, req *sendUndelegationRequest) {
-	m.s.Acquire(context.Background(), 1)
+	// do not check the error, as only way for it to return err is if provided context would be cancelled
+	// which can't happen here
+	_ = m.s.Acquire(context.Background(), 1)
 	m.wg.Add(1)
 	go func() {
 		defer m.s.Release(1)

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -105,6 +105,7 @@ func defaultStakerConfig(t *testing.T, passphrase string) (*stakercfg.Config, *r
 
 	defaultConfig.StakerConfig.BabylonStallingInterval = 1 * time.Second
 	defaultConfig.StakerConfig.UnbondingTxCheckInterval = 1 * time.Second
+	defaultConfig.StakerConfig.MaxConcurrentTransactions = 5
 
 	testRpcClient, err := rpcclient.New(&rpcclient.ConnConfig{
 		Host:                 bitcoindHost,

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -209,7 +209,7 @@ func NewStakerAppFromConfig(
 		return nil, fmt.Errorf("unknown fee estimation mode: %d", config.BtcNodeBackendConfig.EstimationMode)
 	}
 
-	babylonMsgSender := cl.NewBabylonMsgSender(babylonClient, logger, uint64(config.StakerConfig.MaxConcurrentTransactions))
+	babylonMsgSender := cl.NewBabylonMsgSender(babylonClient, logger, config.StakerConfig.MaxConcurrentTransactions)
 
 	return NewStakerAppFromDeps(
 		config,

--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -209,7 +209,7 @@ func NewStakerAppFromConfig(
 		return nil, fmt.Errorf("unknown fee estimation mode: %d", config.BtcNodeBackendConfig.EstimationMode)
 	}
 
-	babylonMsgSender := cl.NewBabylonMsgSender(babylonClient, logger)
+	babylonMsgSender := cl.NewBabylonMsgSender(babylonClient, logger, uint64(config.StakerConfig.MaxConcurrentTransactions))
 
 	return NewStakerAppFromDeps(
 		config,

--- a/stakercfg/config.go
+++ b/stakercfg/config.go
@@ -129,7 +129,7 @@ func DefaultBtcNodeBackendConfig() BtcNodeBackendConfig {
 type StakerConfig struct {
 	BabylonStallingInterval   time.Duration `long:"babylonstallinginterval" description:"The interval for Babylon node BTC light client to catch up with the real chain before re-sending delegation request"`
 	UnbondingTxCheckInterval  time.Duration `long:"unbondingtxcheckinterval" description:"The interval for staker whether delegation received all covenant signatures"`
-	MaxConcurrentTransactions time.Duration `long:"maxconcurrenttransactions" description:"Maximum concurrent transactions in flight to babylon node"`
+	MaxConcurrentTransactions uint64        `long:"maxconcurrenttransactions" description:"Maximum concurrent transactions in flight to babylon node"`
 	ExitOnCriticalError       bool          `long:"exitoncriticalerror" description:"Exit stakerd on critical error"`
 }
 

--- a/stakercfg/config.go
+++ b/stakercfg/config.go
@@ -127,16 +127,18 @@ func DefaultBtcNodeBackendConfig() BtcNodeBackendConfig {
 }
 
 type StakerConfig struct {
-	BabylonStallingInterval  time.Duration `long:"babylonstallinginterval" description:"The interval for Babylon node BTC light client to catch up with the real chain before re-sending delegation request"`
-	UnbondingTxCheckInterval time.Duration `long:"unbondingtxcheckinterval" description:"The interval for staker whether delegation received all covenant signatures"`
-	ExitOnCriticalError      bool          `long:"exitoncriticalerror" description:"Exit stakerd on critical error"`
+	BabylonStallingInterval   time.Duration `long:"babylonstallinginterval" description:"The interval for Babylon node BTC light client to catch up with the real chain before re-sending delegation request"`
+	UnbondingTxCheckInterval  time.Duration `long:"unbondingtxcheckinterval" description:"The interval for staker whether delegation received all covenant signatures"`
+	MaxConcurrentTransactions time.Duration `long:"maxconcurrenttransactions" description:"Maximum concurrent transactions in flight to babylon node"`
+	ExitOnCriticalError       bool          `long:"exitoncriticalerror" description:"Exit stakerd on critical error"`
 }
 
 func DefaultStakerConfig() StakerConfig {
 	return StakerConfig{
-		BabylonStallingInterval:  1 * time.Minute,
-		UnbondingTxCheckInterval: 30 * time.Second,
-		ExitOnCriticalError:      true,
+		BabylonStallingInterval:   1 * time.Minute,
+		UnbondingTxCheckInterval:  30 * time.Second,
+		MaxConcurrentTransactions: 1,
+		ExitOnCriticalError:       true,
 	}
 }
 

--- a/stakercfg/config.go
+++ b/stakercfg/config.go
@@ -129,7 +129,7 @@ func DefaultBtcNodeBackendConfig() BtcNodeBackendConfig {
 type StakerConfig struct {
 	BabylonStallingInterval   time.Duration `long:"babylonstallinginterval" description:"The interval for Babylon node BTC light client to catch up with the real chain before re-sending delegation request"`
 	UnbondingTxCheckInterval  time.Duration `long:"unbondingtxcheckinterval" description:"The interval for staker whether delegation received all covenant signatures"`
-	MaxConcurrentTransactions uint64        `long:"maxconcurrenttransactions" description:"Maximum concurrent transactions in flight to babylon node"`
+	MaxConcurrentTransactions uint32        `long:"maxconcurrenttransactions" description:"Maximum concurrent transactions in flight to babylon node"`
 	ExitOnCriticalError       bool          `long:"exitoncriticalerror" description:"Exit stakerd on critical error"`
 }
 


### PR DESCRIPTION
Naive way of sending conccurent delegations i.e sending them in transactions without waiting for their inclusion. It will work fine as long as our rpc client correctly updates sequence numbers of the account