### PR TITLE
docs: fix the missing option of bitcoind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Please update the following configurations in the provided file:
    and this [link](https://github.com/bitcoin/bitcoin/pull/28597).
 4. If you want to enable remote connections to the node, you can add
    `rpcallowip=0.0.0.0/0` and `rpcbind=0.0.0.0` to the bitcoind command.
+5. Start the `bitcoind` with `-txindex` option to make sure btc-staker can get 
+   all needed bitcoin transaction data.
 
 ```bash 
 # Create the service file
@@ -72,6 +74,7 @@ ExecStart=/home/ubuntu/bitcoin-26.0/bin/bitcoind \
     -deprecatedrpc=create_bdb \
     -signet \
     -server \
+    -txindex \
     -rpcport=38332 \
     -rpcuser=<your_rpc_username> \
     -rpcpassword=<your_rpc_password>


### PR DESCRIPTION
Hi babylon team,

When starting the bitcoind for babylon btc staking, the `-txindex` option is need. So the `btc-staker` can query all the needed transaction data. I think there is an issue #131 about it. 

This PR is adding the missing option into the readme. 