### PR TITLE
update circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   build_lint_test:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:current
     resource_class: large
     steps:
       - go/install:
@@ -42,7 +42,7 @@ jobs:
 
   build_docker:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:current
       resource_class: large
     steps:
       - checkout
@@ -64,7 +64,7 @@ jobs:
 
   push_docker:
     machine:
-      image: ubuntu-2204:2022.10.1
+      image: ubuntu-2204:current
       resource_class: large
     steps:
       - attach_workspace:


### PR DESCRIPTION
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177
ubuntu-2204:2022.10.1 is deprecated.

So circleci's ubuntu image is being updated.
I looked into why this image was specified, and since there didn't seem to be any problem, I specified current.