### PR TITLE
chore: update the broken link for the Signet faucet

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ stakercli daemon babylon-finality-providers
 Find the BTC address that has sufficient Bitcoin balance that you want to stake from.
 
 **Note**: In case you don't have addresses with adequate balances, you can use the
-faucet to receive signet BTC. Visit the faucet [link](https://signet.bc-2.jp/) to
+faucet to receive signet BTC. Visit the faucet [link](https://signetfaucet.com/) to
 acquire signet BTC.
 
 ```bash


### PR DESCRIPTION
This PR updates the broken link for the Signet faucet (previously [link](https://signet.bc-2.jp/) which returns a 404 error) to the new [link](https://signetfaucet.com/).