### PR TITLE
Add method to arbitrary msg using bip322

### DIFF
--- a/walletcontroller/client.go
+++ b/walletcontroller/client.go
@@ -273,7 +273,7 @@ func (w *RpcWalletController) SignBip322NativeSegwit(msg []byte, address btcutil
 	}
 
 	if !txscript.IsPayToWitnessPubKeyHash(toSpend.TxOut[0].PkScript) {
-		return nil, fmt.Errorf("")
+		return nil, fmt.Errorf("Bip322NativeSegwit support only native segwit addresses")
 	}
 
 	toSpendhash := toSpend.TxHash()
@@ -282,7 +282,7 @@ func (w *RpcWalletController) SignBip322NativeSegwit(msg []byte, address btcutil
 
 	amt := float64(0)
 	signed, all, err := w.SignRawTransactionWithWallet2(toSign, []btcjson.RawTxWitnessInput{
-		btcjson.RawTxWitnessInput{
+		{
 			Txid:         toSpendhash.String(),
 			Vout:         0,
 			ScriptPubKey: hex.EncodeToString(toSpend.TxOut[0].PkScript),

--- a/walletcontroller/interface.go
+++ b/walletcontroller/interface.go
@@ -36,4 +36,5 @@ type WalletController interface {
 	SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
 	ListOutputs(onlySpendable bool) ([]Utxo, error)
 	TxDetails(txHash *chainhash.Hash, pkScript []byte) (*notifier.TxConfirmation, TxStatus, error)
+	SignBip322NativeSegwit(msg []byte, address btcutil.Address) (wire.TxWitness, error)
 }


### PR DESCRIPTION
ref: https://github.com/babylonchain/pm/issues/48

One of the places where staker program dumps private key is when creating pop for Babylon: https://github.com/babylonchain/btc-staker/blob/5ab83e6792c4d66b024bc568d9d16acbc7f39df1/staker/stakerapp.go#L1460

To remove `DumPrivateKey` function pop needs to be created in some other way. 

Unfortunately, we cannot use https://developer.bitcoin.org/reference/rpc/signmessage.html bitcoind api as this does not work for native segwit addresses (only legacy ones which should be avoided) . See: https://github.com/bitcoin/bitcoin/issues/10542

Fortunately, Babylon supports pop with bip322 signatures. This pr add necessary api to create such signature along with the test. Followup pr will switch creating pop to this functions 
