### PR TITLE
Use bip322 to build pop through bitcoind

### DIFF
--- a/staker/stakerapp.go
+++ b/staker/stakerapp.go
@@ -1273,28 +1273,6 @@ func (app *StakerApp) BabylonController() cl.BabylonClient {
 	return app.babylonClient
 }
 
-// Generate proof of possessions for staker address.
-// Requires btc wallet to be unlocked!
-func (app *StakerApp) generatePop(stakerPrivKey *btcec.PrivateKey) (*cl.BabylonPop, error) {
-	// build proof of possession, no point moving forward if staker does not have all
-	// the necessary keys
-	babylonAddrHash := tmhash.Sum(app.babylonClient.GetKeyAddress().Bytes())
-	btcSig, err := schnorr.Sign(stakerPrivKey, babylonAddrHash)
-	if err != nil {
-		return nil, err
-	}
-
-	pop, err := cl.NewBabylonPop(
-		cl.SchnorrType,
-		btcSig.Serialize(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate pop: %w", err)
-	}
-
-	return pop, nil
-}
-
 func GetMinStakingTime(p *cl.StakingParams) uint32 {
 	// Actual minimum staking time in babylon is k+w, but setting it to that would
 	// result in delegation which have voting power for 0 btc blocks.

--- a/walletcontroller/client.go
+++ b/walletcontroller/client.go
@@ -99,13 +99,25 @@ func (w *RpcWalletController) UnlockWallet(timoutSec int64) error {
 }
 
 func (w *RpcWalletController) AddressPublicKey(address btcutil.Address) (*btcec.PublicKey, error) {
-	privKey, err := w.DumpPrivKey(address)
+	encoded := address.EncodeAddress()
+
+	info, err := w.GetAddressInfo(encoded)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return privKey.PrivKey.PubKey(), nil
+	if info.PubKey == nil {
+		return nil, fmt.Errorf("address %s has no public key", encoded)
+	}
+
+	decodedHex, err := hex.DecodeString(*info.PubKey)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return btcec.ParsePubKey(decodedHex)
 }
 
 func (w *RpcWalletController) DumpPrivateKey(address btcutil.Address) (*btcec.PrivateKey, error) {


### PR DESCRIPTION
ref: https://github.com/babylonchain/pm/issues/48

One of the steps to remove to remove `DumpPrivateKey` from codebase:
- build pop using bip322 function
- change `AddressPublicKey` to use `GetAddressInfo` endpoint

Next step will be to switch all taproot signing methods to use psbt's.