### PR TITLE
Encapsulate signing into separate function

### DIFF
--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -294,7 +294,7 @@ func StartManager(
 	err = walletClient.UnlockWallet(20)
 	require.NoError(t, err)
 
-	walletPrivKey, err := walletClient.DumpPrivateKey(minerAddressDecoded)
+	walletPrivKey, err := c.DumpPrivKey(minerAddressDecoded)
 	require.NoError(t, err)
 
 	interceptor, err := signal.Intercept()
@@ -334,7 +334,7 @@ func StartManager(
 		Db:               dbbackend,
 		Sa:               stakerApp,
 		BabylonClient:    bl,
-		WalletPrivKey:    walletPrivKey,
+		WalletPrivKey:    walletPrivKey.PrivKey,
 		MinerAddr:        minerAddressDecoded,
 		serverStopper:    &interceptor,
 		wg:               &wg,

--- a/staker/babylontypes.go
+++ b/staker/babylontypes.go
@@ -39,7 +39,12 @@ func (app *StakerApp) buildOwnedDelegation(
 
 	slashingFee := app.getSlashingFee(externalData.babylonParams.MinSlashingTxFeeSat)
 
-	slashingTx, slashingTxSig, err := buildSlashingTxAndSig(slashingFee, externalData, storedTx, app.network)
+	stakingSlashingTx, stakingSlashingSpendInfo, err := slashingTxForStakingTx(
+		slashingFee,
+		externalData,
+		storedTx,
+		app.network,
+	)
 	if err != nil {
 		// This is truly unexpected, most probably programming error we have
 		// valid and btc confirmed staking transacion, but for some reason we cannot
@@ -55,9 +60,9 @@ func (app *StakerApp) buildOwnedDelegation(
 	// in case of estimation failure (25 sat/byte)
 	unbondingTxFeeRatePerKb := btcutil.Amount(app.feeEstimator.EstimateFeePerKb())
 
-	undelegationData, err := createUndelegationData(
+	undelegationDesc, err := createUndelegationData(
 		storedTx,
-		externalData.stakerPrivKey,
+		externalData.stakerPublicKey,
 		externalData.babylonParams.CovenantPks,
 		externalData.babylonParams.CovenantQuruomThreshold,
 		externalData.babylonParams.SlashingAddress,
@@ -74,16 +79,46 @@ func (app *StakerApp) buildOwnedDelegation(
 		return nil, fmt.Errorf("error creating undelegation data: %w", err)
 	}
 
+	stakingSlashingSig, err := app.signTaprootScriptSpendUsingWallet(
+		stakingSlashingTx,
+		storedTx.StakingTx.TxOut[storedTx.StakingOutputIndex],
+		stakerAddress,
+		&stakingSlashingSpendInfo.RevealedLeaf,
+		&stakingSlashingSpendInfo.ControlBlock,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("error signing slashing transaction for staking transaction: %w", err)
+	}
+
+	unbondingSlashingSig, err := app.signTaprootScriptSpendUsingWallet(
+		undelegationDesc.SlashUnbondingTransaction,
+		undelegationDesc.UnbondingTransaction.TxOut[0],
+		stakerAddress,
+		&undelegationDesc.SlashUnbondingTransactionSpendInfo.RevealedLeaf,
+		&undelegationDesc.SlashUnbondingTransactionSpendInfo.ControlBlock,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("error signing slashing transaction for unbonding transaction: %w", err)
+	}
+
 	dg := createDelegationData(
-		externalData.stakerPrivKey.PubKey(),
+		externalData.stakerPublicKey,
 		req.inclusionBlock,
 		req.txIndex,
 		storedTx,
-		slashingTx,
-		slashingTxSig,
+		stakingSlashingTx,
+		stakingSlashingSig,
 		externalData.babylonStakerAddr,
 		stakingTxInclusionProof,
-		undelegationData,
+		&cl.UndelegationData{
+			UnbondingTransaction:         undelegationDesc.UnbondingTransaction,
+			UnbondingTxValue:             undelegationDesc.UnbondingTxValue,
+			UnbondingTxUnbondingTime:     undelegationDesc.UnbondingTxUnbondingTime,
+			SlashUnbondingTransaction:    undelegationDesc.SlashUnbondingTransaction,
+			SlashUnbondingTransactionSig: unbondingSlashingSig,
+		},
 	)
 
 	return dg, nil


### PR DESCRIPTION
- removes `DumpPrivateKey` from interface
- encapsulate signing into separate function

This changes will make it possible to:
- first switch to signing through psbts
- then bumping bitcoin node version in tests